### PR TITLE
fix: ページリフレッシュ時の白画面を修正

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -17,6 +17,26 @@
         "source": "**",
         "destination": "/index.html"
       }
+    ],
+    "headers": [
+      {
+        "source": "**",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "no-cache, no-store, must-revalidate"
+          }
+        ]
+      },
+      {
+        "source": "**/*.@(js|css)",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "public, max-age=31536000"
+          }
+        ]
+      }
     ]
   },
   "emulators": {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,12 +4,19 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
-  base: './',
+  base: '/',
   server: {
     headers: {
       'Cross-Origin-Opener-Policy': 'unsafe-none',
       'Cross-Origin-Embedder-Policy': 'unsafe-none',
       'Cross-Origin-Resource-Policy': 'cross-origin',
+    }
+  },
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks: undefined
+      }
     }
   }
 })


### PR DESCRIPTION
直接URLアクセスやページリフレッシュ時に白画面が表示される問題を修正。

- vite.config.tsのbase pathを'./'から'/'に変更
- firebase.jsonにキャッシュ制御ヘッダーを追加